### PR TITLE
Support multiple values in proxy headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,12 @@ function ReqIp (header) {
   header = header || 'x-forwarded-for'
 
   return function ip (req, res, callback) {
-    req.ip = req.headers[header] || req.connection.remoteAddress
+    req.ip = proxyHeader(req, header) || req.connection.remoteAddress
     callback()
   }
+}
+
+function proxyHeader (req, header) {
+  const value = req.headers[header]
+  return value && value.split(', ')[0]
 }

--- a/test.js
+++ b/test.js
@@ -19,7 +19,27 @@ test('default header', function (t) {
   function dispatch (req, res) {
     ip(req, res, function (err) {
       if (err) return t.end(err)
-      t.equal(req.ip, '1.2.3.4')
+      t.equal(req.ip, '1.2.3.4', 'uses x-forwarded-for header')
+    })
+  }
+})
+
+test('multiple proxies', function (t) {
+  t.plan(1)
+
+  const ip = ReqIp()
+
+  inject(dispatch, {
+    url: '/',
+    headers: {
+      'x-forwarded-for': '1.2.3.4, 5.6.7.8'
+    }
+  }, t.fail)
+
+  function dispatch (req, res) {
+    ip(req, res, function (err) {
+      if (err) return t.end(err)
+      t.equal(req.ip, '1.2.3.4', 'uses first x-forwarded-for entry')
     })
   }
 })
@@ -39,7 +59,7 @@ test('custom header', function (t) {
   function dispatch (req, res) {
     ip(req, res, function (err) {
       if (err) return t.end(err)
-      t.equal(req.ip, '10.20.30.40')
+      t.equal(req.ip, '10.20.30.40', 'uses custom header')
     })
   }
 })
@@ -56,7 +76,7 @@ test('not forwarded', function (t) {
   function dispatch (req, res) {
     ip(req, res, function (err) {
       if (err) return t.end(err)
-      t.equal(req.ip, '127.0.0.1')
+      t.equal(req.ip, '127.0.0.1', 'falls back to remoteAddress')
     })
   }
 })


### PR DESCRIPTION
Suports the following valid input:

```
X-Forwarded-For: 1.2.3.4, 5.6.7.8
```

The general [format](https://en.wikipedia.org/wiki/X-Forwarded-For#Format) is:

```
X-Forwarded-For: client, proxy1, proxy2
```

The client IP is what we want here.

Closes #1